### PR TITLE
Adds JSON extension as a Composer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Added
+- Added `ext-json` as a Composer dependency.
+
 ### Changed
 - Removed the WordPress query post limit of 5 posts when querying for services without a specific limit.
 

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^5.4 | ^7.0",
+        "ext-json": ">=1.2.1",
         "rebelcode/modular": "^0.1-alpha1",
         "rebelcode/transformers": "^0.1-alpha1",
         "rebelcode/wp-cqrs-resource-models": "^0.2-alpha1",


### PR DESCRIPTION
The PHP version used to develop this module is `PHP-NTS Win x86 5.4.0`.  
The version of the JSON extension that is bundled with this version is `1.2.1`.
